### PR TITLE
Fix messages being "received" out of sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,6 +540,9 @@ Connection.prototype.connect = function(address, port, privateName, priority, gr
         that._data(data);
     });
 
+    this.socket.on('error', function (error) {
+        that.emit('error', error);
+    })
 };
 
 Connection.connect = Connection.prototype.connect;

--- a/index.js
+++ b/index.js
@@ -544,9 +544,9 @@ Connection.prototype.connect = function(address, port, privateName, priority, gr
         that.emit('error', error);
     });
 
-    this.socket.on('close', function () {
+    this.socket.on('close', function (had_error) {
         that.state = undefined;
-        that.emit('close', new Error('Close'));
+        that.emit('close', had_error);
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -542,7 +542,12 @@ Connection.prototype.connect = function(address, port, privateName, priority, gr
 
     this.socket.on('error', function (error) {
         that.emit('error', error);
-    })
+    });
+
+    this.socket.on('close', function () {
+        that.state = undefined;
+        that.emit('close', new Error('Close'));
+    });
 };
 
 Connection.connect = Connection.prototype.connect;

--- a/index.js
+++ b/index.js
@@ -476,6 +476,11 @@ Connection.prototype._data = function(data) {
         }
 
         this.buffer = this.buffer.slice(this.offset);
+        
+        // Check if buffer still has conent and if so, continue digesting
+        if (this.buffer.length > 0) {
+            this._data( new Buffer(0));
+        }
     } catch (e) {
         this.emit("error", e);
     }

--- a/index.js
+++ b/index.js
@@ -564,7 +564,7 @@ Connection.prototype.multicast = function(service_type, groups, message_type, me
     // Check if we're connected.
     if(this.state != STATE_CONNECTED)
     {
-        this.emit("error", new SpreadException("Not connected."));
+        return this.emit("error", new SpreadException("Not connected."));
     }
 
     if ( ! Array.isArray(groups) ) {
@@ -578,7 +578,7 @@ Connection.prototype.multicast = function(service_type, groups, message_type, me
 
     if (numBytes + message.length > MAX_MESSAGE_LENGTH )
     {
-        this.emit("error", new SpreadException("Message is too long for a Spread Message"));
+        return this.emit("error", new SpreadException("Message is too long for a Spread Message"));
     }
     // Allocate the send buffer.
     var buffer = new Buffer(numBytes);

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ Connection.prototype. internal_receive = function() {
     var type; // A short
 
     // Is this a regular message?
-    if ( (serviceType & Connection.REGULAR_MESS && ! serviceType & Connection.REJECT_MESS) || serviceType & Connection.REJECT_MESS) {
+    if ( (serviceType & Connection.REGULAR_MESS && !(serviceType & Connection.REJECT_MESS)) || serviceType & Connection.REJECT_MESS) {
 
         // Get the type from the hint.
         hint = clearEndian(hint);

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ Connection.prototype.readString = function(n) {
     }
     var str = this.buffer.toString('ascii', this.offset, this.offset + n);
     this.offset += n;
-    return str;
+    return str.replace(/\0/g, '');
 };
 
 Connection.prototype.ignoreBytes = function(n) {

--- a/index.js
+++ b/index.js
@@ -576,6 +576,12 @@ Connection.prototype.multicast = function(service_type, groups, message_type, me
     numBytes += MAX_GROUP_NAME;  // private group
     numBytes += (MAX_GROUP_NAME * groups.length);  // groups
 
+    if (typeof message === 'string') {
+        message = new Buffer(message);
+    } else if (!Buffer.isBuffer(message)) {
+        return this.emit("error", new SpreadException("Message is neither a string nor a buffer"));
+    }
+
     if (numBytes + message.length > MAX_MESSAGE_LENGTH )
     {
         return this.emit("error", new SpreadException("Message is too long for a Spread Message"));


### PR DESCRIPTION
Continue reading from buffer until it is empty.

When multiple messages are being received in short order (for example two joins `join1` and `join2` followed by single broadcast `data1`) the buffer is filled with these multiple messages, but we were only reading the first message here `join1`, leaving the rest in the buffer (now `join2, data1`). Later when another message `data2` was received, that message was appended to the buffer, and we read once, returning `join2`, leaving a none-empty buffer with `data1, data1`.
